### PR TITLE
freeze node-zopfli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "co": "^4.0.0",
-    "node-zopfli": "^1.2.0",
+    "node-zopfli": "1.2.0",
     "node.extend": "^1.1.3",
     "shark-transformer": "0.2.0",
     "shark-tree": "0.2.1",


### PR DESCRIPTION
to provide support for both node v11 and v12
